### PR TITLE
feat(fluxbox): replace openbox with fluxbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,10 +44,6 @@ RUN --mount=type=secret,id=vnc_password \
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 RUN mkdir -p /var/log/supervisord
 
-# 配置 Openbox 和 Xvfb
-COPY openbox-autostart.sh /root/.config/openbox/autostart
-RUN chmod +x /root/.config/openbox/autostart
-
 # 暴露端口
 EXPOSE ${VNC_PORT} ${NOVNC_PORT}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        software-properties-common wget curl supervisor x11vnc xvfb openbox python3 ca-certificates && \
+        software-properties-common wget curl supervisor x11vnc xvfb fluxbox python3 ca-certificates && \
     . /etc/os-release && CODENAME=${UBUNTU_CODENAME:-${VERSION_CODENAME}} && \
     mkdir -pm755 /etc/apt/keyrings && \
     wget -q -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key && \

--- a/openbox-autostart.sh
+++ b/openbox-autostart.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-# 在这里添加要自动启动的Wine应用程序
-wine notepad &

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -21,13 +21,13 @@ priority=20
 stdout_logfile=/var/log/supervisord/x11vnc.log     ; x11vnc 日志文件路径
 stderr_logfile=/var/log/supervisord/x11vnc_error.log ; x11vnc 错误日志文件路径
 
-[program:openbox]
-command=openbox-session
+[program:fluxbox]
+command=fluxbox
 autostart=true
 autorestart=true
 priority=30
-stdout_logfile=/var/log/supervisord/openbox.log    ; openbox 日志文件路径
-stderr_logfile=/var/log/supervisord/openbox_error.log ; openbox 错误日志文件路径
+stdout_logfile=/var/log/supervisord/fluxbox.log    ; fluxbox 日志文件路径
+stderr_logfile=/var/log/supervisord/fluxbox_error.log ; fluxbox 错误日志文件路径
 
 [program:novnc]
 command=/opt/novnc/utils/novnc_proxy --vnc localhost:%(ENV_VNC_PORT)s --listen %(ENV_NOVNC_PORT)s


### PR DESCRIPTION
This PR replaces Openbox with Fluxbox as the window manager to provide a more user-friendly and out-of-the-box experience. 

Changes:
- Updated Dockerfile to install Fluxbox instead of Openbox.
- Modified supervisord.conf to start Fluxbox.
- Removed Openbox-related configuration files.

Testing:
- Built and tested Docker image locally.
- Verified noVNC and Fluxbox work as expected.
