### PR TITLE
feat(supervisor): modularize supervisor configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,14 @@ RUN --mount=type=secret,id=vnc_password \
     mkdir -p /root/.vnc && \
     x11vnc -storepasswd $(cat /run/secrets/vnc_password) /root/.vnc/passwd
 
-# 配置 supervisord 和日志目录
-COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-RUN mkdir -p /var/log/supervisord
+# 创建 supervisor 配置目录和日志目录并复制独立配置文件
+RUN mkdir -p /etc/supervisor/conf.d /var/log/supervisord
+COPY supervisord.conf /etc/supervisor/supervisord.conf
+COPY supervisor/conf.d/* /etc/supervisor/conf.d/
+
 
 # 暴露端口
 EXPOSE ${VNC_PORT} ${NOVNC_PORT}
 
 # 启动 supervisord
-CMD ["sh", "-c", "/usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf"]
+CMD ["sh", "-c", "/usr/bin/supervisord -c /etc/supervisor/supervisord.conf"]

--- a/supervisor/conf.d/fluxbox.conf
+++ b/supervisor/conf.d/fluxbox.conf
@@ -1,0 +1,7 @@
+[program:fluxbox]
+command=fluxbox
+autostart=true
+autorestart=true
+priority=30
+stdout_logfile=/var/log/supervisord/fluxbox.log
+stderr_logfile=/var/log/supervisord/fluxbox_error.log

--- a/supervisor/conf.d/novnc.conf
+++ b/supervisor/conf.d/novnc.conf
@@ -1,0 +1,7 @@
+[program:novnc]
+command=/opt/novnc/utils/novnc_proxy --vnc localhost:%(ENV_VNC_PORT)s --listen 0.0.0.0:%(ENV_NOVNC_PORT)s
+autostart=true
+autorestart=true
+priority=40
+stdout_logfile=/var/log/supervisord/novnc.log
+stderr_logfile=/var/log/supervisord/novnc_error.log

--- a/supervisor/conf.d/x11vnc.conf
+++ b/supervisor/conf.d/x11vnc.conf
@@ -1,0 +1,7 @@
+[program:x11vnc]
+command=x11vnc -display :1 -rfbport %(ENV_VNC_PORT)s -rfbauth /root/.vnc/passwd
+autostart=true
+autorestart=true
+priority=20
+stdout_logfile=/var/log/supervisord/x11vnc.log
+stderr_logfile=/var/log/supervisord/x11vnc_error.log

--- a/supervisor/conf.d/xvfb.conf
+++ b/supervisor/conf.d/xvfb.conf
@@ -1,0 +1,7 @@
+[program:xvfb]
+command=Xvfb :1 -screen 0 1024x768x16
+autostart=true
+autorestart=true
+priority=10
+stdout_logfile=/var/log/supervisord/xvfb.log
+stderr_logfile=/var/log/supervisord/xvfb_error.log

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,38 +1,10 @@
 [supervisord]
 nodaemon=true
-logfile=/var/log/supervisord/supervisord.log      ; 全局日志文件路径
-logfile_maxbytes=50MB                              ; 最大日志文件大小
-logfile_backups=10                                 ; 日志备份数量
-loglevel=info                                      ; 日志级别
+logfile=/var/log/supervisord/supervisord.log
+logfile_maxbytes=50MB
+logfile_backups=10
+loglevel=info
 
-[program:xvfb]
-command=Xvfb :1 -screen 0 1024x768x16
-autostart=true
-autorestart=true
-priority=10
-stdout_logfile=/var/log/supervisord/xvfb.log       ; xvfb 日志文件路径
-stderr_logfile=/var/log/supervisord/xvfb_error.log ; xvfb 错误日志文件路径
-
-[program:x11vnc]
-command=x11vnc -display :1 -rfbport %(ENV_VNC_PORT)s -rfbauth /root/.vnc/passwd
-autostart=true
-autorestart=true
-priority=20
-stdout_logfile=/var/log/supervisord/x11vnc.log     ; x11vnc 日志文件路径
-stderr_logfile=/var/log/supervisord/x11vnc_error.log ; x11vnc 错误日志文件路径
-
-[program:fluxbox]
-command=fluxbox
-autostart=true
-autorestart=true
-priority=30
-stdout_logfile=/var/log/supervisord/fluxbox.log    ; fluxbox 日志文件路径
-stderr_logfile=/var/log/supervisord/fluxbox_error.log ; fluxbox 错误日志文件路径
-
-[program:novnc]
-command=/opt/novnc/utils/novnc_proxy --vnc localhost:%(ENV_VNC_PORT)s --listen %(ENV_NOVNC_PORT)s
-autostart=true
-autorestart=true
-priority=40
-stdout_logfile=/var/log/supervisord/novnc.log      ; novnc 日志文件路径
-stderr_logfile=/var/log/supervisord/novnc_error.log ; novnc 错误日志文件路径
+; Include all configurations from conf.d directory
+[include]
+files = /etc/supervisor/conf.d/*.conf


### PR DESCRIPTION
Modularized `supervisor` configuration by separating each service into individual files under `supervisor/conf.d/`. This improves maintainability and makes it easier to manage each service configuration independently.

**Changes**:
- Created separate configuration files for `xvfb`, `x11vnc`, `fluxbox`, and `novnc`.
- Updated `supervisord.conf` to include configurations from `conf.d/`.
- Adjusted `Dockerfile` to copy individual config files.

**Testing**:
- Built and tested Docker image locally.
- Verified that all services start correctly and logs are properly generated.