### PR TITLE
docs(readme): update documentation for Fluxbox, Supervisor modular configuration, and default BuildKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 - **Wine**: 支持运行 Windows 应用程序。
 - **noVNC**: 通过 WebSocket 提供浏览器访问 VNC 虚拟桌面。
 - **x11vnc**: 提供 VNC 虚拟桌面服务。
-- **Openbox**: 轻量级窗口管理器。
-- **Supervisor**: 管理和监控多进程服务。
+- **Fluxbox**: 轻量级、开箱即用的窗口管理器。
+- **Supervisor**: 管理和监控多进程服务，配置为模块化的方式以便维护和扩展。
 
 ## 快速开始
 
@@ -25,7 +25,7 @@ docker pull invelop/wine-novnc:latest
 ```bash
 git clone https://github.com/p0ise/wine-novnc-docker.git
 cd wine-novnc-docker
-DOCKER_BUILDKIT=1 docker build --secret id=vnc_password,src=./vnc_password.txt -t wine-novnc .
+docker build --secret id=vnc_password,src=./vnc_password.txt -t wine-novnc .
 ```
 
 ### 运行容器
@@ -48,12 +48,12 @@ docker run -p 6080:6080 -p 5901:5901 --secret id=vnc_password,src=./vnc_password
 your_secure_vnc_password
 ```
 
-### 启用 BuildKit 和秘密挂载
+### 使用 BuildKit 和秘密挂载
 
-在使用 BuildKit 构建时，通过以下命令指定秘密文件：
+默认情况下，BuildKit 已经启用。通过以下命令构建镜像并指定秘密文件：
 
 ```bash
-DOCKER_BUILDKIT=1 docker build --secret id=vnc_password,src=./vnc_password.txt -t wine-novnc .
+docker build --secret id=vnc_password,src=./vnc_password.txt -t wine-novnc .
 ```
 
 并在运行容器时使用相同的秘密文件：
@@ -74,17 +74,21 @@ docker run -p 6080:6080 -p 5901:5901 --secret id=vnc_password,src=./vnc_password
 项目的主要文件包括：
 
 - `Dockerfile`：定义镜像构建步骤，配置 Wine、VNC、noVNC 及其他依赖。
-- `supervisord.conf`：配置 supervisord，管理和监控多个服务进程。
-- `openbox-autostart.sh`：用于自定义 Openbox 启动时运行的应用程序。
+- `supervisord.conf`：主 `supervisor` 配置文件，包含基本设置并引入模块化配置。
+- `supervisor/conf.d/`：包含各服务的独立 `supervisor` 配置文件：
+  - `xvfb.conf`：配置 Xvfb 虚拟显示服务。
+  - `x11vnc.conf`：配置 x11vnc VNC 服务。
+  - `fluxbox.conf`：配置 Fluxbox 窗口管理器。
+  - `novnc.conf`：配置 noVNC 服务。
 - `download_gecko_and_mono.sh`：下载并配置 Wine 的 Gecko 和 Mono 支持文件，确保 Wine 的完整运行环境。
 - `vnc_password.txt`：包含 VNC 密码的文件，通过 Docker BuildKit 的秘密挂载功能在构建和运行时注入。
 
 ## 自定义配置
 
-您可以在 `openbox-autostart.sh` 中自定义启动时运行的应用程序。例如，可以在 Openbox 启动时通过 Wine 运行特定的 Windows 应用：
+在 `fluxbox.conf` 中可以自定义 Fluxbox 的启动配置，或通过扩展 Fluxbox 的启动脚本加载特定应用程序。例如，可以在 Fluxbox 启动时通过 Wine 运行特定的 Windows 应用：
 
-```bash
-# openbox-autostart.sh
+```plaintext
+# 在 Fluxbox 配置中添加启动命令
 wine /path/to/your/windows-app.exe
 ```
 
@@ -96,7 +100,7 @@ wine /path/to/your/windows-app.exe
 - `xvfb.log`：记录 Xvfb 服务的日志，虚拟显示的运行状态。
 - `x11vnc.log`：记录 x11vnc 服务的日志，提供 VNC 访问信息。
 - `novnc.log`：记录 noVNC 服务的日志，提供 WebSocket 连接日志。
-- `openbox.log`：记录 Openbox 窗口管理器的日志。
+- `fluxbox.log`：记录 Fluxbox 窗口管理器的日志。
 
 可以通过检查这些日志文件来诊断和监控各个服务的状态。
 


### PR DESCRIPTION
Updated the README documentation to reflect the recent changes:
- Replaced Openbox with Fluxbox as the window manager.
- Documented the modular configuration for Supervisor.
- Removed the instruction to manually enable BuildKit, as it is now default in Docker 23.0 and above.

This improves clarity and aligns the documentation with current project structure and Docker version updates.