### PR TITLE
feat(fluxbox): add xterm terminal support for Fluxbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        software-properties-common wget curl supervisor x11vnc xvfb fluxbox python3 ca-certificates && \
+        software-properties-common wget curl supervisor x11vnc xvfb xterm fluxbox python3 ca-certificates && \
     . /etc/os-release && CODENAME=${UBUNTU_CODENAME:-${VERSION_CODENAME}} && \
     mkdir -pm755 /etc/apt/keyrings && \
     wget -q -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key && \


### PR DESCRIPTION
Added xterm terminal support to the Fluxbox environment. This addition provides a default terminal application that can be accessed within the noVNC interface.

Changes:
- Updated Dockerfile to install xterm alongside Fluxbox.

Testing:
- Built and tested Docker image locally to ensure xterm is accessible and functional within Fluxbox.